### PR TITLE
Set Talk Salute Fix

### DIFF
--- a/datascripts/SmartScript/ActionType.ts
+++ b/datascripts/SmartScript/ActionType.ts
@@ -393,7 +393,7 @@ export class ActionType {
                             Duration:Duration,
                             Text: value,
                             BroadcastTextId: 0,
-                            Emote: 1,
+                            Emote: 0,
                             comment: 'tswow'
                         })
                 } else {

--- a/datascripts/SmartScript/ActionType.ts
+++ b/datascripts/SmartScript/ActionType.ts
@@ -393,6 +393,7 @@ export class ActionType {
                             Duration:Duration,
                             Text: value,
                             BroadcastTextId: 0,
+                            Emote: 1,
                             comment: 'tswow'
                         })
                 } else {


### PR DESCRIPTION
Basically a couple weeks ago we noticed that `setTalk` in smart scripts was making the creature Salute almost every time. I quickly bodged this fix in locally but probably needs PRing up. 

This may not be the _right_ solution however and you might want to default to 0 (no emote) rather than the actual talk emote.